### PR TITLE
fix ~/.fonts conditional parsing, d'oh.

### DIFF
--- a/install
+++ b/install
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # ensure ~/.fonts exists
-if ! [ -d "~/.fonts" ]; then
+if [ ! -d ~/.fonts ]; then
     mkdir ~/.fonts
 fi
 


### PR DESCRIPTION
Fixed ! inside [ ] block and quotes around ~/.fonts as that's expanded by the shell. 
